### PR TITLE
Add /git-branch skill and update approve/create for non-worktree workflow

### DIFF
--- a/skills/git-branch/SKILL.md
+++ b/skills/git-branch/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: git-branch
+description: 新しい作業を開始するときに GitHub Issue を作成し、ブランチを作成する（Worktree なし）。main 上の未プッシュコミットがある場合は自動でブランチに移植する。
+disable-model-invocation: false
+user-invocable: true
+allowed-tools:
+  - Bash
+  - mcp__github__issue_write
+  - mcp__github__get_me
+---
+
+# Git ブランチ作成スキル（Issue-first、Worktree なし）
+
+## 引数の処理
+
+- **引数なし** (`/git-branch`): 「作業内容を伝えてください」と表示して **停止する。それ以上何もしない。**
+- **引数あり** (`/git-branch ダークモード対応`): 引数を Issue タイトルとして使用し、以下のフローを実行する。
+
+## 実行フロー（引数ありの場合）
+
+### 1. リポジトリ情報を取得
+
+```bash
+git remote -v
+```
+
+出力から `owner` と `repo` を特定する。
+
+### 2. GitHub Issue を作成
+
+`mcp__github__issue_write` を使用：
+- method: `create`
+- owner: （リポジトリオーナー）
+- repo: （リポジトリ名）
+- title: ユーザーの引数をそのまま使用
+- body: 作業の概要を簡潔に記載
+
+### 3. ブランチ名を生成
+
+1. ユーザーの引数を英語スラッグに変換する
+   - 小文字、ハイフン区切り、英数字のみ
+   - 3〜5単語程度に簡潔にまとめる
+   - 例: `ダークモード追加` → `add-dark-mode`
+2. ブランチ名: `issue-<Issue番号>-<英語スラッグ>`
+   - 例: `issue-17-add-dark-mode`
+
+### 4. ブランチを作成
+
+現在のブランチと未プッシュコミットの状態を判定し、適切な方法でブランチを作成する。
+
+#### ケース A: main/master にいて、未プッシュコミットがある場合
+
+```bash
+# デフォルトブランチ名を判定（main または master）
+git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+
+# 現在のブランチを確認
+git branch --show-current
+
+# 未プッシュコミットがあるか確認
+git log origin/<デフォルトブランチ>..HEAD --oneline
+```
+
+コミットがある場合:
+```bash
+git checkout -b <ブランチ名>        # 現在位置からブランチ作成（コミット含む）
+git branch -f <デフォルトブランチ> origin/<デフォルトブランチ>  # main/master を origin にリセット
+```
+
+#### ケース B: それ以外（main/master にいてコミットなし、または別ブランチ）
+
+```bash
+git checkout -b <ブランチ名>
+```
+
+### 5. 完了メッセージ
+
+以下の形式で出力する：
+
+**ケース A（コミット移植あり）の場合:**
+
+```
+処理が終了しました。
+
+Issue: #<Issue番号> - <Issueタイトル>
+ブランチ: <ブランチ名>
+
+<デフォルトブランチ> にあった未プッシュコミット（<コミット数>件）をブランチに移植しました。
+<デフォルトブランチ> は origin/<デフォルトブランチ> にリセットされました。
+```
+
+**ケース B（通常）の場合:**
+
+```
+処理が終了しました。
+
+Issue: #<Issue番号> - <Issueタイトル>
+ブランチ: <ブランチ名>
+```
+
+**これ以上何も出力しない。コード編集・次のステップの提案は一切しない。**

--- a/skills/github-pr-approve/SKILL.md
+++ b/skills/github-pr-approve/SKILL.md
@@ -90,10 +90,21 @@ gh issue close <Issue番号>
 
 作業ブランチから master ブランチに戻る。
 
+**まず Worktree を使用しているか判定する:**
+
 ```bash
-cd ../<メインディレクトリ>  # メインリポジトリに戻る（Worktree使用時）
-git checkout master
+git worktree list
 ```
+
+- **出力が2行以上** → Worktree 使用中:
+  ```bash
+  cd ../<メインディレクトリ>  # メインリポジトリに戻る
+  git checkout master
+  ```
+- **出力が1行のみ** → 通常ブランチ:
+  ```bash
+  git checkout master
+  ```
 
 ### 4. リモートの最新状態を取得と不要ブランチ削除
 
@@ -104,18 +115,23 @@ git pull
 git fetch --prune
 ```
 
-### 5. Worktree の削除（Worktree使用時のみ）
+### 5. 後片付け（Worktree / ブランチの削除）
 
-Git Worktree を使用していた場合、作業ディレクトリを削除する。
+Step 3 で判定した結果に基づいて後片付けを行う。
 
-```bash
-git worktree remove ../<プロジェクト名>-<ブランチ種別>
-```
+- **Worktree 使用中の場合:** Worktree を削除する
+  ```bash
+  git worktree remove ../<プロジェクト名>-<ブランチ種別>
+  ```
+  **例:**
+  ```bash
+  git worktree remove ../myproject-feature
+  ```
 
-**例:**
-```bash
-git worktree remove ../myproject-feature
-```
+- **通常ブランチの場合:** ローカルブランチを削除する
+  ```bash
+  git branch -d <ブランチ名>
+  ```
 
 ### 6. 完了メッセージをユーザーに表示
 
@@ -130,9 +146,9 @@ git worktree remove ../myproject-feature
 - Issue #[Issue番号] をクローズ
 - master ブランチに切り替え
 - リモートの最新状態を取得
-- Worktree を削除（使用時のみ）
+- Worktree を削除 / ローカルブランチを削除
 
-新しい作業を開始する場合は、`/git-worktree-branch` スキルをご利用ください。
+新しい作業を開始する場合は、`/git-worktree-branch` または `/git-branch` スキルをご利用ください。
 ```
 
 ## 実行例

--- a/skills/github-pr-create/SKILL.md
+++ b/skills/github-pr-create/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools:
 
 このスキルは、作業完了時にブランチ名から Issue 番号を検出し、PR を作成して紐付けを行います。
 
-**Issue は `/git-worktree-branch` または `/git-worktree-from-issue` で事前に作成済みであることが前提です。**
+**Issue は `/git-worktree-branch`、`/git-worktree-from-issue`、または `/git-branch` で事前に作成済みであることが前提です。**
 
 ## 前提条件の確認
 


### PR DESCRIPTION
## 概要

Worktree なしのブランチ作成スキル `/git-branch` を追加し、既存スキルを対応させる。

## 変更内容

- **`skills/git-branch/SKILL.md`（新規）**: Worktree を使わない軽量なブランチ作成スキル
  - main/master 上の未プッシュコミットを自動でブランチに移植する機能付き
- **`skills/github-pr-approve/SKILL.md`（修正）**: `git worktree list` で Worktree 使用を判定し、後片付けを条件分岐
- **`skills/github-pr-create/SKILL.md`（修正）**: 前提条件に `/git-branch` を追記

Closes #26