### PR TITLE
fix: hooks設定を新フォーマットに修正 (#28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ tasks/
 # Claude Code内部設定ファイル
 .claude/
 .credentials.json
-settings.json
 settings.local.json
 
 # IDEとプラグイン

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -ExecutionPolicy Bypass -File \"$(wslpath -w ~/.claude/windows-notify.ps1)\" -Title \"応答完了\" -Message \"処理が完了しました\" -IncludeWorkingDirectory"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- `settings.json` の hooks 設定を新フォーマット（`matcher` 文字列 + `hooks` 配列）に修正
- `.gitignore` から `settings.json` を除外解除し、Git 追跡対象に追加

## Related Issue
Closes #28

## Test plan
- [ ] `claude` コマンド起動時に hooks 設定エラーが出ないことを確認
- [ ] Stop フック（応答完了通知）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)