### PR TITLE
feat: WezTerm のウィンドウタイトルにカレントディレクトリ名を表示

### DIFF
--- a/windows/.wezterm.lua
+++ b/windows/.wezterm.lua
@@ -1,6 +1,25 @@
 local wezterm = require 'wezterm'
 local act = wezterm.action
 
+-- パスから末尾ディレクトリ名だけ取り出す
+local function basename(path)
+  path = path:gsub('^file://', '')
+  return path:gsub('(.*[/\\])(.*)', '%2')
+end
+
+-- ウィンドウタイトルにカレントディレクトリ名を表示
+wezterm.on('format-window-title', function(window, tab, panes, config)
+  if not tab then
+    return 'WezTerm'
+  end
+  local pane = tab.active_pane
+  if not pane then
+    return 'WezTerm'
+  end
+  local cwd = basename(tostring(pane.current_working_dir or ''))
+  return cwd .. ' - WezTerm'
+end)
+
 local config = wezterm.config_builder()
 
 -- WSL 関連


### PR DESCRIPTION
## 概要

`.wezterm.lua` に `format-window-title` イベントハンドラを追加し、ウィンドウタイトルバーにアクティブペインのカレントディレクトリ名を表示するようにしました。

## 変更内容

- `basename` ヘルパー関数を追加（パスから末尾ディレクトリ名を抽出）
- `format-window-title` ハンドラでウィンドウタイトルを `<ディレクトリ名> - WezTerm` 形式に設定
- 分割ペイン使用時もフォーカス中のペインのディレクトリ名が表示される

Closes #64