### PR TITLE
.gitignore の plugins/ パターンを修正して nvim プラグインファイルを追跡できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ shell-snapshots/
 paste-cache/
 plans/
 projects/
-plugins/
 ide/
 statsig/
 todos/


### PR DESCRIPTION
Closes #75

## 変更内容

- `.gitignore` の `plugins/` パターンを削除
  - `.claude/` が既に29行目でignoreされているため `plugins/` 行は冗長かつ有害だった
  - `wsl/.config/nvim/lua/plugins/` 配下の nvim プラグインファイルが誤って除外されていた問題を修正