### PR TITLE
WezTerm: フォーカス時にIMEを自動OFFにする設定を追加

### DIFF
--- a/windows/.wezterm.lua
+++ b/windows/.wezterm.lua
@@ -290,4 +290,22 @@ config.key_tables = {
   },
 }
 
+----------------------------------------------------
+-- フォーカス時 IME OFF
+----------------------------------------------------
+-- 他アプリからWezTermにフォーカスが移った瞬間だけIMEをOFFにする。
+-- WezTerm内のタブ・ペイン移動では window-focus-changed は発火しないため、
+-- その場合はIME状態を変更しない。
+wezterm.on('window-focus-changed', function(window, pane)
+  if window:is_focused() then
+    -- VK_DBE_ALPHANUMERIC (0xF0): トグルではなく「常にアルファベットモードへ」
+    wezterm.run_child_process({
+      'powershell.exe',
+      '-NoLogo', '-NonInteractive', '-WindowStyle', 'Hidden',
+      '-Command',
+      [[Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class Ime{[DllImport("user32.dll")]public static extern void keybd_event(byte v,byte s,uint f,IntPtr e);public static void Off(){keybd_event(0xF0,0,0,IntPtr.Zero);keybd_event(0xF0,0,2,IntPtr.Zero);}}';[Ime]::Off()]],
+    })
+  end
+end)
+
 return config


### PR DESCRIPTION
Closes #99

## 変更内容

### windows/.wezterm.lua
- `window-focus-changed` イベントで WezTerm にフォーカスが移った瞬間に IME を自動 OFF にする設定を追加
- `VK_DBE_ALPHANUMERIC (0xF0)` を powershell 経由で送信することで、トグルではなく常にアルファベットモードに切り替える
- WezTerm 内のタブ・ペイン移動では発火しないため、誤動作を防止