### PR TITLE
Qiita公開ワークフローのパスをdocs/qiitaに修正

### DIFF
--- a/.github/workflows/publish-qiita.yml
+++ b/.github/workflows/publish-qiita.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - '3_output/qiita/**.md'
+      - 'docs/qiita/**.md'
   workflow_dispatch:
 
 jobs:
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: noraworld/github-to-qiita@v1.0.1
         with:
-          dir: 3_output/qiita
+          dir: docs/qiita
           qiita_access_token: ${{ secrets.QIITA_TOKEN }}


### PR DESCRIPTION
Closes #104

## 変更内容
- 監視パスを `3_output/qiita/` → `docs/qiita/` に修正
- 記事配置ディレクトリを `docs/qiita/` に統一