### PR TITLE
worktreeウィジェットとime-off.exe対応

### DIFF
--- a/docs/qiita/terminal-shortcuts.md
+++ b/docs/qiita/terminal-shortcuts.md
@@ -143,7 +143,7 @@ Leader キーは `Ctrl+q`（2秒タイムアウト）。
 |---------|------|------|
 | `cfd` | カレントディレクトリ直下のフォルダを fzf で選んで `cd` | **c**d + **f**zf + **d**irectory |
 | `wcd "C:\..."` | Windows パスを WSL パスに変換して `cd` + Claude Code 起動 | **W**indows **cd** |
-| `gw` | `~/.git-worktrees/` 以下の worktree を fzf で選択して `cd` | **g**it **w**orktrees |
+| `Alt+W` | `~/.git-worktrees/` 以下の worktree を fzf で選択して `cd` | **W**orktree |
 
 ---
 

--- a/windows/.wezterm.lua
+++ b/windows/.wezterm.lua
@@ -112,13 +112,8 @@ end)
 ----------------------------------------------------
 -- IME OFF ユーティリティ
 ----------------------------------------------------
--- VK_DBE_ALPHANUMERIC (0xF0): トグルではなく「常にアルファベットモードへ」
-local IME_OFF_CMD = {
-  'powershell.exe',
-  '-NoLogo', '-NonInteractive', '-WindowStyle', 'Hidden',
-  '-Command',
-  [[Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class Ime{[DllImport("user32.dll")]public static extern void keybd_event(byte v,byte s,uint f,IntPtr e);public static void Off(){keybd_event(0xF0,0,0,IntPtr.Zero);keybd_event(0xF0,0,2,IntPtr.Zero);}}';[Ime]::Off()]],
-}
+-- ime-off.exe: keybd_event(VK_DBE_ALPHANUMERIC) でGoogle日本語入力をOFF
+local IME_OFF_CMD = { 'C:/Users/SeiyaKawashima/bin/ime-off.exe' }
 
 -- アクション実行前にIMEをOFFにするラッパー
 local function with_ime_off(action)

--- a/wsl/.zshrc
+++ b/wsl/.zshrc
@@ -74,8 +74,8 @@ function ghq-fzf() {
 zle -N ghq-fzf
 bindkey '^G' ghq-fzf
 
-# ~/.git-worktrees 以下の worktree を fzf で選択して cd（4〜5階層のみ、.bare 除外）
-gw() {
+# ~/.git-worktrees 以下の worktree を fzf で選択して cd（4〜5階層のみ、.bare 除外）Alt+W
+function worktree-fzf() {
   local base="$HOME/.git-worktrees"
 
   local target
@@ -87,7 +87,10 @@ gw() {
   ) || return
 
   cd "$target"
+  zle reset-prompt
 }
+zle -N worktree-fzf
+bindkey '\ew' worktree-fzf
 
 # WSL_INTEROP をサブプロセスに引き継ぐ
 if [ -z "$WSL_INTEROP" ]; then


### PR DESCRIPTION
Closes #118


## 変更内容

- **worktree選択をZLEウィジェット化**: `gw` シェル関数を `worktree-fzf` ZLEウィジェットに変更し、`Alt+W` キーバインドで呼び出せるように設定
- **ime-off.exe を使用**: WezTerm の IME OFF 実装を PowerShell スクリプトから `ime-off.exe` に置き換え
- **ショートカット一覧を更新**: `docs/qiita/terminal-shortcuts.md` の `gw` エントリを `Alt+W` に更新

## テスト方法

1. WezTerm を再起動し、ペイン・タブ切り替え時に IME が OFF になることを確認
2. `Alt+W` で `~/.git-worktrees/` 以下の worktree 一覧が fzf 表示されることを確認
3. worktree を選択後、`cd` されプロンプトが更新されることを確認