### PR TITLE
WezTerm IME OFF機能を削除

### DIFF
--- a/claude/skills/gh-finish/gh-finish.sh
+++ b/claude/skills/gh-finish/gh-finish.sh
@@ -87,7 +87,11 @@ detect_context() {
   CURRENT_BRANCH=$(git branch --show-current)
 
   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
-    | sed 's@^refs/remotes/origin/@@' || echo "main")
+    | sed 's@^refs/remotes/origin/@@')
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep "HEAD branch" | awk '{print $NF}')
+  fi
+  DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 
   # OWNER/REPO
   local remote_url

--- a/windows/.wezterm.lua
+++ b/windows/.wezterm.lua
@@ -92,34 +92,13 @@ wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_wid
   }
 end)
 
-----------------------------------------------------
--- IME OFF ユーティリティ
-----------------------------------------------------
--- ime-off.exe: keybd_event(VK_DBE_ALPHANUMERIC) でGoogle日本語入力をOFF
-local IME_OFF_CMD = { 'C:/Users/SeiyaKawashima/bin/ime-off.exe' }
-
--- アクション実行前にIMEをOFFにするラッパー
-local function with_ime_off(action)
-  return wezterm.action_callback(function(window, pane)
-    wezterm.run_child_process(IME_OFF_CMD)
-    window:perform_action(action, pane)
-  end)
-end
 
 ----------------------------------------------------
 -- keybinds
 ----------------------------------------------------
 
 -- Show which key table is active in the status area
-local last_pane_id = nil
 wezterm.on("update-right-status", function(window, pane)
-  -- ペインが切り替わったら IME OFF（ペイン切り替え後に実行）
-  local pane_id = pane:pane_id()
-  if pane_id ~= last_pane_id then
-    last_pane_id = pane_id
-    wezterm.run_child_process(IME_OFF_CMD)
-  end
-
   local key_table = window:active_key_table()
   local workspace = wezterm.mux.get_active_workspace()
   local status = workspace
@@ -184,9 +163,9 @@ config.keys = {
   },
   -- コマンドパレット表示
   { key = "p", mods = "CTRL", action = act.ActivateCommandPalette },
-  -- Tab移動（IME OFF）
-  { key = "Tab", mods = "CTRL", action = with_ime_off(act.ActivateTabRelative(1)) },
-  { key = "Tab", mods = "SHIFT|CTRL", action = with_ime_off(act.ActivateTabRelative(-1)) },
+  -- Tab移動
+  { key = "Tab", mods = "CTRL", action = act.ActivateTabRelative(1) },
+  { key = "Tab", mods = "SHIFT|CTRL", action = act.ActivateTabRelative(-1) },
   -- Tab入れ替え
   { key = ",", mods = "ALT", action = act({ MoveTabRelative = -1 }) },
   -- Tab新規作成
@@ -210,11 +189,11 @@ config.keys = {
   { key = "r", mods = "LEADER", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
   -- Paneを閉じる leader + x
   { key = "x", mods = "LEADER", action = act({ CloseCurrentPane = { confirm = true } }) },
-  -- Pane移動 Alt + hjkl（IME OFF）
-  { key = "h", mods = "ALT", action = with_ime_off(act.ActivatePaneDirection("Left")) },
-  { key = "l", mods = "ALT", action = with_ime_off(act.ActivatePaneDirection("Right")) },
-  { key = "k", mods = "ALT", action = with_ime_off(act.ActivatePaneDirection("Up")) },
-  { key = "j", mods = "ALT", action = with_ime_off(act.ActivatePaneDirection("Down")) },
+  -- Pane移動 Alt + hjkl
+  { key = "h", mods = "ALT", action = act.ActivatePaneDirection("Left") },
+  { key = "l", mods = "ALT", action = act.ActivatePaneDirection("Right") },
+  { key = "k", mods = "ALT", action = act.ActivatePaneDirection("Up") },
+  { key = "j", mods = "ALT", action = act.ActivatePaneDirection("Down") },
   -- Pane選択
   { key = "[", mods = "CTRL|SHIFT", action = act.PaneSelect },
   -- 選択中のPaneのみ表示
@@ -226,16 +205,16 @@ config.keys = {
   -- フォントサイズのリセット
   { key = "0", mods = "CTRL", action = act.ResetFontSize },
 
-  -- タブ切替 Ctrl + 数字（IME OFF）
-  { key = "1", mods = "CTRL", action = with_ime_off(act.ActivateTab(0)) },
-  { key = "2", mods = "CTRL", action = with_ime_off(act.ActivateTab(1)) },
-  { key = "3", mods = "CTRL", action = with_ime_off(act.ActivateTab(2)) },
-  { key = "4", mods = "CTRL", action = with_ime_off(act.ActivateTab(3)) },
-  { key = "5", mods = "CTRL", action = with_ime_off(act.ActivateTab(4)) },
-  { key = "6", mods = "CTRL", action = with_ime_off(act.ActivateTab(5)) },
-  { key = "7", mods = "CTRL", action = with_ime_off(act.ActivateTab(6)) },
-  { key = "8", mods = "CTRL", action = with_ime_off(act.ActivateTab(7)) },
-  { key = "9", mods = "CTRL", action = with_ime_off(act.ActivateTab(-1)) },
+  -- タブ切替 Ctrl + 数字
+  { key = "1", mods = "CTRL", action = act.ActivateTab(0) },
+  { key = "2", mods = "CTRL", action = act.ActivateTab(1) },
+  { key = "3", mods = "CTRL", action = act.ActivateTab(2) },
+  { key = "4", mods = "CTRL", action = act.ActivateTab(3) },
+  { key = "5", mods = "CTRL", action = act.ActivateTab(4) },
+  { key = "6", mods = "CTRL", action = act.ActivateTab(5) },
+  { key = "7", mods = "CTRL", action = act.ActivateTab(6) },
+  { key = "8", mods = "CTRL", action = act.ActivateTab(7) },
+  { key = "9", mods = "CTRL", action = act.ActivateTab(-1) },
 
   -- コマンドパレット
   { key = "p", mods = "SHIFT|CTRL", action = act.ActivateCommandPalette },
@@ -312,11 +291,5 @@ config.key_tables = {
   },
 }
 
--- 他アプリからWezTermにフォーカスが移った時もIME OFF
-wezterm.on('window-focus-changed', function(window, pane)
-  if window:is_focused() then
-    wezterm.run_child_process(IME_OFF_CMD)
-  end
-end)
 
 return config


### PR DESCRIPTION
Closes #122


## 変更内容

- `windows/.wezterm.lua`: IME OFF ユーティリティ（`with_ime_off` ラッパー、`last_pane_id` によるペイン切り替え検知、`window-focus-changed` イベント）を完全削除。Tab移動・Pane移動・タブ切替のキーバインドをシンプルなアクションに変更
- `claude/skills/gh-finish/gh-finish.sh`: `DEFAULT_BRANCH` 検出ロジックを改善。`git symbolic-ref` が空の場合に `git remote show origin` でフォールバック取得するよう修正

## テスト方法

- WezTerm を起動し、Ctrl+Tab / Alt+hjkl / Ctrl+数字 でタブ・ペイン切り替えが正常に動作することを確認
- `gh-finish.sh` を実行し、`origin/HEAD` が未設定なリポジトリでもデフォルトブランチが正しく検出されることを確認