### PR TITLE
WezTerm WSL2ペイン自動起動対応

### DIFF
--- a/claude/skills/gh-worktree-branch/create-worktree.sh
+++ b/claude/skills/gh-worktree-branch/create-worktree.sh
@@ -42,3 +42,20 @@ echo ""
 echo "=== Worktree 作成完了 ==="
 echo "ブランチ: $BRANCH"
 echo "ディレクトリ: $WORKTREE_ABSPATH"
+
+# WezTerm で新しいペインを開いて Claude を起動
+# ネイティブ: wezterm + WEZTERM_PANE が必要
+# WSL2: wezterm.exe で代替（WEZTERM_PANE 不要）
+_wezterm_cmd=""
+if command -v wezterm &>/dev/null && [ -n "${WEZTERM_PANE:-}" ]; then
+  _wezterm_cmd="wezterm"
+elif command -v wezterm.exe &>/dev/null; then
+  _wezterm_cmd="wezterm.exe"
+elif [ -x "/mnt/c/Program Files/WezTerm/wezterm.exe" ]; then
+  _wezterm_cmd="/mnt/c/Program Files/WezTerm/wezterm.exe"
+fi
+
+if [ -n "$_wezterm_cmd" ]; then
+  "$_wezterm_cmd" cli split-pane --cwd "$WORKTREE_ABSPATH" -- zsh -l -c "export PATH=\"\$HOME/.local/bin:\$PATH\"; ~/.local/bin/claude"
+  echo "WezTerm: 新しいペインで Claude を起動しました。"
+fi

--- a/docs/qiita/terminal-shortcuts.md
+++ b/docs/qiita/terminal-shortcuts.md
@@ -110,6 +110,22 @@ Leader キーは `Ctrl+q`（2秒タイムアウト）。
 | `Ctrl+Shift+r` | 設定を再読み込み | **r**eload |
 | `Alt+Enter` | フルスクリーン切り替え | Enter = 確定・最大化 |
 
+### SSH（Tailscale 経由）
+
+外出先から Tailscale 経由でリモートマシンに接続するとき、通常の `ssh` コマンドの代わりに `wezterm ssh` を使うと、WezTerm のペイン分割などのローカル機能がそのまま使える。
+
+```bash
+# 通常の SSH（WezTerm の機能は使えない）
+ssh user@tailscale-hostname
+
+# WezTerm SSH（リモート側に WEZTERM_PANE が自動でセットされる）
+wezterm ssh user@tailscale-hostname
+```
+
+Tailscale の IP（`100.x.x.x`）や MagicDNS 名がそのまま使える。
+
+**なぜ動くか：** `wezterm ssh` は SSH 接続時に WezTerm のマルチプレクサをセットアップし、リモート側に `WEZTERM_PANE` と `WEZTERM_UNIX_SOCKET` を自動でセットする。これにより `wezterm cli split-pane` などのコマンドがリモートからでも動作する。
+
 ---
 
 ## Zsh キーバインド


### PR DESCRIPTION
Closes #124


## 変更内容

- `create-worktree.sh`: Worktree 作成後に WezTerm で新しいペインを開き Claude を自動起動する処理を追加
  - ネイティブ環境: `wezterm` コマンド + `WEZTERM_PANE` 環境変数で判定
  - WSL2 環境: `wezterm.exe`（パス自動検索）で代替
  - いずれの WezTerm も見つからない場合はスキップ
- `docs/qiita/terminal-shortcuts.md`: WezTerm SSH（Tailscale 経由）セクションを追加
  - `wezterm ssh` を使うとリモート側でもペイン分割などのローカル機能が使える旨を説明

## テスト方法

1. WSL2 環境で `create-worktree.sh` を実行し、新しいペインが開いて Claude が起動することを確認
2. `wezterm.exe` が存在しない環境でスクリプトを実行し、エラーなくスキップされることを確認
3. ネイティブ Linux 環境（`WEZTERM_PANE` あり）で実行し、`wezterm cli split-pane` が呼ばれることを確認