### PR TITLE
nvim-tree/Telescope連携強化とショートカット更新

### DIFF
--- a/docs/qiita/terminal-shortcuts.md
+++ b/docs/qiita/terminal-shortcuts.md
@@ -375,6 +375,8 @@ Leader キーは `Space`。
 | `<leader>ee` | エディタにフォーカスを戻す | **e**xplorer **e**xit |
 | `<leader>er` | カーソル下のディレクトリをルートに変更して再表示 | **e**xplorer **r**oot |
 | `Ctrl+]` | フォルダを nvim-tree 内部のルートに変更（`:pwd` は変わらない） | `]` = 深く潜る（vim 慣習） |
+| `W` | ツリー全体を折りたたむ（collapse all） | 大文字で全体操作 |
+| `E` | ツリー全体を再帰的に展開（expand all） | 大文字で全体操作 |
 
 ##### 絞り込み
 
@@ -491,6 +493,7 @@ Neovim 内の Claude Code は「閉じて再度開く」ことで再起動でき
 | `exit` または `Ctrl+D` | Claude Code セッションを終了 | exit / EOF（**D** = end of file） |
 | `claude` | 新規セッションで Claude Code を起動 | コマンド名そのまま |
 | `claude -r <セッション名>` | 指定セッションで再開 | **r**esume |
+| `claude da` | 権限確認をスキップして起動（danger mode） | **da**nger の略 |
 
 #### Claude Code プロンプト入力
 

--- a/wsl/.config/nvim/lazy-lock.json
+++ b/wsl/.config/nvim/lazy-lock.json
@@ -14,5 +14,5 @@
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "snacks.nvim": { "branch": "main", "commit": "a049339328e2599ad6e85a69fa034ac501e921b2" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "6fea601bd2b694c6f2ae08a6c6fab14930c60e2c" },
-  "telescope.nvim": { "branch": "master", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" }
+  "telescope.nvim": { "branch": "master", "commit": "5255aa27c422de944791318024167ad5d40aad20" }
 }

--- a/wsl/.config/nvim/lua/plugins/telescope.lua
+++ b/wsl/.config/nvim/lua/plugins/telescope.lua
@@ -1,18 +1,28 @@
 return {
   {
     "nvim-telescope/telescope.nvim",
-    tag = "0.1.8",
-    dependencies = {
+dependencies = {
       "nvim-lua/plenary.nvim",
       { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
     },
     config = function()
       local telescope = require("telescope")
       local builtin = require("telescope.builtin")
+      local actions = require("telescope.actions")
+
+      -- ファイルを開いた後に nvim-tree でそのファイルを選択状態にする
+      local function open_and_reveal(prompt_bufnr)
+        actions.select_default(prompt_bufnr)
+        require("nvim-tree.api").tree.find_file({ open = true, focus = false })
+      end
 
       telescope.setup({
         defaults = {
           file_ignore_patterns = { "node_modules", ".git/" },
+          mappings = {
+            i = { ["<CR>"] = open_and_reveal },
+            n = { ["<CR>"] = open_and_reveal },
+          },
         },
         extensions = {
           fzf = {},

--- a/wsl/.zshrc
+++ b/wsl/.zshrc
@@ -95,9 +95,9 @@ bindkey '\ew' worktree-fzf
 # gh finish: Issue作成〜PRマージまで一括実行
 alias gf='bash ~/.claude/skills/gh-finish/gh-finish.sh'
 
-# claude -d: --dangerously-skip-permissions の短縮
+# claude da: --dangerously-skip-permissions の短縮
 claude() {
-  if [[ "$1" == "-d" ]]; then
+  if [[ "$1" == "da" ]]; then
     shift
     command claude --dangerously-skip-permissions "$@"
   else


### PR DESCRIPTION
Closes #132


## 変更内容

### Telescope → nvim-tree 連携
- Telescope でファイルを開いた際、nvim-tree 上でそのファイルを自動選択状態にする `open_and_reveal` 関数を追加
- `<CR>` キーマッピングに適用（insert/normal モード両対応）
- `telescope.nvim` を tag 指定から branch 追跡に変更し、最新コミットに更新

### nvim-tree ショートカット追加
- `W`: ツリー全体を折りたたむ（collapse all）
- `E`: ツリー全体を再帰的に展開（expand all）

### claude コマンドのショートカット変更
- `claude -d` → `claude da`（`--dangerously-skip-permissions` の短縮）

### ドキュメント更新
- `docs/qiita/terminal-shortcuts.md` に上記変更を反映

## テスト方法

1. Telescope でファイルを検索し `<CR>` で開く → nvim-tree が開き、該当ファイルがフォーカスされることを確認
2. nvim-tree で `W` キー押下 → 全フォルダが折りたたまれることを確認
3. nvim-tree で `E` キー押下 → 全フォルダが再帰的に展開されることを確認
4. `claude da` コマンドが `--dangerously-skip-permissions` 付きで起動することを確認