### PR TITLE
WezTerm起動時に最終ディレクトリを復元

### DIFF
--- a/windows/.wezterm.lua
+++ b/windows/.wezterm.lua
@@ -2,6 +2,27 @@ local wezterm = require("wezterm")
 local act = wezterm.action
 local config = wezterm.config_builder()
 
+-- WSL の ~/.last_dir から直近のディレクトリを取得
+local function get_last_dir()
+  local success, stdout = wezterm.run_child_process({
+    "wsl.exe", "-e", "cat", "/home/seiya-kawashima/.last_dir",
+  })
+  if success and stdout and stdout ~= "" then
+    return stdout:gsub("%s+$", "")
+  end
+  return nil
+end
+
+-- WezTerm 起動時に直近のディレクトリで開く
+wezterm.on("gui-startup", function(cmd)
+  local last_dir = get_last_dir()
+  local args = cmd or {}
+  if last_dir then
+    args.cwd = last_dir
+  end
+  wezterm.mux.spawn_window(args)
+end)
+
 
 config.automatically_reload_config = true
 config.font_size = 12.0
@@ -191,8 +212,23 @@ config.keys = {
   { key = "Tab", mods = "SHIFT|CTRL", action = act.ActivateTabRelative(-1) },
   -- Tab入れ替え
   { key = ",", mods = "ALT", action = act({ MoveTabRelative = -1 }) },
-  -- Tab新規作成
-  { key = "t", mods = "CTRL", action = act({ SpawnTab = "CurrentPaneDomain" }) },
+  -- Tab新規作成（現在のペインのCWD → ~/.last_dir の順でフォールバック）
+  {
+    key = "t",
+    mods = "CTRL",
+    action = wezterm.action_callback(function(window, pane)
+      local cwd_uri = pane:get_current_working_dir()
+      local cwd = cwd_uri and cwd_uri.file_path or get_last_dir()
+      if cwd then
+        window:perform_action(
+          act.SpawnCommandInNewTab({ cwd = cwd, domain = "CurrentPaneDomain" }),
+          pane
+        )
+      else
+        window:perform_action(act.SpawnTab("CurrentPaneDomain"), pane)
+      end
+    end),
+  },
   -- Tabを閉じる
   { key = "w", mods = "CTRL", action = act({ CloseCurrentTab = { confirm = true } }) },
   { key = ".", mods = "ALT", action = act({ MoveTabRelative = 1 }) },

--- a/wsl/.config/nvim/lazy-lock.json
+++ b/wsl/.config/nvim/lazy-lock.json
@@ -2,6 +2,7 @@
   "auto-reload.nvim": { "branch": "main", "commit": "635e63d46bcad9c8dc0b0a8c483209e1f2aae465" },
   "claudecode.nvim": { "branch": "main", "commit": "432121f0f5b9bda041030d1e9e83b7ba3a93dd8f" },
   "codex.nvim": { "branch": "main", "commit": "e1149cbc875ff71ee21f8832b9fe815a270442b3" },
+  "csvview.nvim": { "branch": "main", "commit": "7022e18a0fbae9aecf99a3ba02b2a541edc2b8a1" },
   "kanagawa.nvim": { "branch": "master", "commit": "aef7f5cec0a40dbe7f3304214850c472e2264b10" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "markdown-preview.nvim": { "branch": "master", "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee" },

--- a/wsl/.config/nvim/lua/plugins/csvview.lua
+++ b/wsl/.config/nvim/lua/plugins/csvview.lua
@@ -1,0 +1,5 @@
+return {
+  "hat0uma/csvview.nvim",
+  opts = {},
+  cmd = { "CsvViewEnable", "CsvViewDisable", "CsvViewToggle" },
+}

--- a/wsl/.zshrc
+++ b/wsl/.zshrc
@@ -53,6 +53,10 @@ __wezterm_osc7() {
   printf '\e]7;file://%s%s\e\\' "$(hostname)" "$PWD"
 }
 precmd_functions+=(__wezterm_osc7)
+
+# 最後に訪れたディレクトリを保存（WezTerm の新規タブ/ウィンドウで使用）
+__save_last_dir() { echo "$PWD" > ~/.last_dir }
+chpwd_functions+=(__save_last_dir)
 export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
 
 # Windows パスを WSL パスに変換して claude を起動


### PR DESCRIPTION
Closes #135


## 変更内容

### WezTerm (`windows/.wezterm.lua`)
- 起動時に WSL の `~/.last_dir` を読み込み、最後に居たディレクトリで新規ウィンドウを開く `gui-startup` イベントハンドラを追加
- `Ctrl+T` の新規タブ作成を拡張：現在のペインの CWD → `~/.last_dir` の順でフォールバックし、同じディレクトリで開く

### Zsh (`wsl/.zshrc`)
- `chpwd_functions` に `__save_last_dir` を追加し、ディレクトリ移動のたびに `~/.last_dir` へ現在のパスを保存

### Neovim
- `csvview.nvim` プラグインを追加（CSV ファイルをテーブル表示）
- `lazy-lock.json` を更新

## テスト方法

1. WSL ターミナルで任意のディレクトリに移動し、`~/.last_dir` にパスが保存されることを確認
   ```sh
   cd ~/ghq/github.com && cat ~/.last_dir
   ```
2. WezTerm を再起動し、`~/.last_dir` に保存されたディレクトリで起動することを確認
3. `Ctrl+T` で新規タブを開き、現在のペインと同じディレクトリで開くことを確認
4. Neovim で CSV ファイルを開き、`:CsvViewToggle` でテーブル表示が切り替わることを確認