### PR TITLE
nvim-tree リロードと CSV 自動表示を追加

### DIFF
--- a/docs/qiita/terminal-shortcuts.md
+++ b/docs/qiita/terminal-shortcuts.md
@@ -405,6 +405,7 @@ Leader キーは `Space`。
 | `Ctrl+n` | ファイルツリーを開閉 | **n**vim-tree |
 | `<leader>ef` | nvim-tree にフォーカス（閉じていれば開く） | **e**xplorer **f**ocus |
 | `<leader>ee` | エディタにフォーカスを戻す | **e**xplorer **e**xit |
+| `<leader>eR` | ツリーを最新状態に更新 | **e**xplorer **R**eload（大文字＝更新） |
 | `<leader>er` | カーソル下のディレクトリをルートに変更して再表示 | **e**xplorer **r**oot |
 | `Ctrl+]` | フォルダを nvim-tree 内部のルートに変更（`:pwd` は変わらない） | `]` = 深く潜る（vim 慣習） |
 | `W` | ツリー全体を折りたたむ（collapse all） | 大文字で全体操作 |

--- a/wsl/.config/nvim/lua/plugins/csvview.lua
+++ b/wsl/.config/nvim/lua/plugins/csvview.lua
@@ -2,4 +2,14 @@ return {
   "hat0uma/csvview.nvim",
   opts = {},
   cmd = { "CsvViewEnable", "CsvViewDisable", "CsvViewToggle" },
+  ft = { "csv", "tsv" },
+  config = function()
+    require("csvview").setup()
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = { "csv", "tsv" },
+      callback = function()
+        require("csvview").enable()
+      end,
+    })
+  end,
 }

--- a/wsl/.config/nvim/lua/plugins/nvim-tree.lua
+++ b/wsl/.config/nvim/lua/plugins/nvim-tree.lua
@@ -127,6 +127,10 @@ return {
       end, { silent = true, desc = "Explorer: focus" })
       vim.keymap.set("n", "<leader>ee", "<C-w>l", { silent = true, desc = "Explorer: back to editor" })
 
+      vim.keymap.set("n", "<leader>eR", function()
+        api.tree.reload()
+      end, { silent = true, desc = "Explorer: reload" })
+
       vim.keymap.set("n", "<leader>er", function()
         api.tree.change_root_to_node()
         api.tree.close()


### PR DESCRIPTION
Closes #137


## 変更内容

### nvim-tree にリロードショートカットを追加
- `<leader>eR` で nvim-tree のファイルツリーを最新状態に更新するキーマップを追加
- `docs/qiita/terminal-shortcuts.md` にも同ショートカットを記載

### CSV/TSV ファイルの自動ビュー表示
- `csvview.nvim` に `ft = { "csv", "tsv" }` を設定し、CSV/TSV ファイルを開いた際に自動で `CsvView` を有効化

## テスト方法

1. **nvim-tree リロード**
   - nvim-tree を開いた状態で `<leader>eR` を押し、ツリーが更新されることを確認

2. **CSV 自動表示**
   - `.csv` または `.tsv` ファイルを Neovim で開き、自動的に整形表示されることを確認
   - `CsvViewDisable` で手動無効化できることも確認