### PR TITLE
worktreeノースプリットクリップボード対応

### DIFF
--- a/claude/skills/gh-worktree-branch/create-worktree.sh
+++ b/claude/skills/gh-worktree-branch/create-worktree.sh
@@ -56,7 +56,7 @@ elif [ -x "/mnt/c/Program Files/WezTerm/wezterm.exe" ]; then
   _wezterm_cmd="/mnt/c/Program Files/WezTerm/wezterm.exe"
 fi
 
-if [ -n "$_wezterm_cmd" ]; then
+if [ "$SPLIT_DIR" != "none" ] && [ -n "$_wezterm_cmd" ]; then
   if [ "$SPLIT_DIR" = "r" ]; then
     "$_wezterm_cmd" cli split-pane --right --cwd "$WORKTREE_ABSPATH" -- zsh -l -c "export PATH=\"\$HOME/.local/bin:\$PATH\"; ~/.local/bin/claude; exit 0"
   else

--- a/wsl/.zshrc
+++ b/wsl/.zshrc
@@ -109,15 +109,33 @@ claude() {
   fi
 }
 
-# gh worktree branch: Issue作成 + worktree作成 + WezTermペイン分割
-# gwb r → 右分割、gwb d → 下分割（デフォルト）
+# gh worktree branch: Issue作成 + worktree作成
+# gwb   → worktree作成してcd "path"をクリップボードにコピー
+# gwb r → 右分割、gwb d → 下分割
 gwb() {
-  local dir="${1:-d}"
   local url
   url=$(gh issue create --title "WIP" --body "") || return 1
   local num
   num=$(echo "$url" | grep -oE '[0-9]+$')
-  bash ~/.claude/skills/gh-worktree-branch/create-worktree.sh "issue-${num}" "$dir"
+  if [[ $# -eq 0 ]]; then
+    local output
+    output=$(bash ~/.claude/skills/gh-worktree-branch/create-worktree.sh "issue-${num}" "none") || return 1
+    echo "$output"
+    local path line
+    while IFS= read -r line; do
+      [[ "$line" == ディレクトリ:* ]] && path="${line#ディレクトリ: }" && break
+    done <<< "$output"
+    if [[ -n "$path" ]]; then
+      local cd_cmd="cd \"$path\""
+      printf '%s' "$cd_cmd" | /mnt/c/Windows/System32/clip.exe
+      echo "クリップボードにコピーしました: $cd_cmd"
+    else
+      echo "警告: ディレクトリパスの取得に失敗しました"
+      echo "スクリプト出力: $output"
+    fi
+  else
+    bash ~/.claude/skills/gh-worktree-branch/create-worktree.sh "issue-${num}" "$1"
+  fi
 }
 
 # WSL_INTEROP をサブプロセスに引き継ぐ


### PR DESCRIPTION
Closes #139


## 変更内容

### `gwb` コマンドの拡張

- **引数なしモード追加**: `gwb` を引数なしで実行すると、WezTermのペイン分割を行わずworktreeを作成し、`cd "path"` コマンドをクリップボードにコピーする
- **既存の分割モードは維持**: `gwb r`（右分割）・`gwb d`（下分割）は従来通り動作

### `create-worktree.sh` の修正

- `SPLIT_DIR=none` の場合はWezTermのペイン分割処理をスキップするよう条件分岐を追加

### ユースケース

| コマンド | 動作 |
|---------|------|
| `gwb` | worktree作成 + `cd "path"` をクリップボードコピー |
| `gwb r` | worktree作成 + 右ペイン分割でClaudeを起動 |
| `gwb d` | worktree作成 + 下ペイン分割でClaudeを起動 |

## テスト方法

1. `gwb` を引数なしで実行し、worktreeが作成されることを確認
2. クリップボードに `cd "/path/to/worktree"` がコピーされていることを確認（ペイン分割が起きないこと）
3. `gwb r` / `gwb d` で従来通りペイン分割が動作することを確認
4. `create-worktree.sh` を `SPLIT_DIR=none` で直接呼び出し、WezTermが起動しないことを確認