### PR TITLE
WezTerm分割ペインにcwd設定

### DIFF
--- a/wsl/.config/nvim/init.lua
+++ b/wsl/.config/nvim/init.lua
@@ -129,7 +129,8 @@ vim.api.nvim_create_autocmd("VimEnter", {
   callback = function()
     require("nvim-tree.api").tree.open()
     vim.schedule(function()
-      vim.fn.system({ wezterm, "cli", "split-pane", "--right", "--percent", "30" })
+      local cwd_win = vim.fn.trim(vim.fn.system("wslpath -w " .. vim.fn.shellescape(vim.fn.getcwd())))
+      vim.fn.system({ wezterm, "cli", "split-pane", "--right", "--percent", "30", "--cwd", cwd_win })
     end)
   end,
 })


### PR DESCRIPTION
Closes #141


## 変更内容

Neovim起動時にWezTermの右ペインを開く際、カレントディレクトリを引き継ぐように修正。

- `wslpath -w` でWSLパスをWindowsパスに変換し、`--cwd` オプションで分割ペインのワーキングディレクトリを指定

## テスト方法

1. WSL上でNeovimを任意のディレクトリで起動
2. 右側に自動で開くWezTermペインのカレントディレクトリがNeovimと同じであることを確認