### PR TITLE
git worktree作成前にgit fetchを追加

### DIFF
--- a/claude/skills/gh-worktree-branch/create-worktree.sh
+++ b/claude/skills/gh-worktree-branch/create-worktree.sh
@@ -14,6 +14,8 @@ GIT_COMMON=$(git rev-parse --git-common-dir)
 if [ "$(basename "$GIT_COMMON")" = ".bare" ]; then
   CONTAINER_DIR="$(dirname "$GIT_COMMON")"
   WORKTREE_DIR="${CONTAINER_DIR}/${BRANCH}"
+  echo "origin から最新を取得中..."
+  git fetch origin
   git worktree add -b "$BRANCH" "$WORKTREE_DIR"
 else
   # モード2: remote URL から ~/.git-worktrees/... の .bare が存在するか確認
@@ -29,6 +31,8 @@ else
       SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
       bash "${SCRIPT_DIR}/../gh-init-worktree/init-worktree.sh" "$(git rev-parse --show-toplevel)"
     fi
+    echo "origin から最新を取得中..."
+    GIT_DIR="${CANDIDATE}/.bare" git fetch origin
     WORKTREE_DIR="${CANDIDATE}/${BRANCH}"
     GIT_DIR="${CANDIDATE}/.bare" git worktree add -b "$BRANCH" "$WORKTREE_DIR"
   else


### PR DESCRIPTION
Closes #143


## 変更内容

`create-worktree.sh` において、worktree 作成前に `git fetch origin` を実行するよう変更。

- bare リポジトリ（モード1）: `git worktree add` 前に `git fetch origin` を実行
- bare リポジトリ（モード2・候補パスあり）: `GIT_DIR` を指定した `git fetch origin` を実行

これにより、worktree 作成時に常に最新のリモートブランチ情報が取得され、古いベースで作業を開始するリスクを低減する。

## テスト方法

1. worktree ベースのリポジトリで `/gh-worktree-branch` または `/gh-worktree-from-issue` を実行
2. `origin から最新を取得中...` のメッセージが表示されることを確認
3. worktree が最新の `origin/main`（または対象ブランチ）ベースで作成されることを確認