### PR TITLE
worktreeブランチ作成時のクリーン化

### DIFF
--- a/claude/skills/gh-worktree-branch/create-worktree.sh
+++ b/claude/skills/gh-worktree-branch/create-worktree.sh
@@ -16,6 +16,9 @@ if [ "$(basename "$GIT_COMMON")" = ".bare" ]; then
   WORKTREE_DIR="${CONTAINER_DIR}/${BRANCH}"
   echo "origin から最新を取得中..."
   git fetch origin
+  git worktree list --porcelain \
+    | awk '/^worktree /{print $2}' | grep -v '\.bare$' \
+    | while IFS= read -r wt; do [ -d "$wt" ] && git -C "$wt" restore . 2>/dev/null || true; done
   git worktree add -b "$BRANCH" "$WORKTREE_DIR"
 else
   # モード2: remote URL から ~/.git-worktrees/... の .bare が存在するか確認
@@ -33,6 +36,9 @@ else
     fi
     echo "origin から最新を取得中..."
     GIT_DIR="${CANDIDATE}/.bare" git fetch origin
+    GIT_DIR="${CANDIDATE}/.bare" git worktree list --porcelain \
+      | awk '/^worktree /{print $2}' | grep -v '\.bare$' \
+      | while IFS= read -r wt; do [ -d "$wt" ] && git -C "$wt" restore . 2>/dev/null || true; done
     WORKTREE_DIR="${CANDIDATE}/${BRANCH}"
     GIT_DIR="${CANDIDATE}/.bare" git worktree add -b "$BRANCH" "$WORKTREE_DIR"
   else
@@ -47,6 +53,10 @@ echo ""
 echo "=== Worktree 作成完了 ==="
 echo "ブランチ: $BRANCH"
 echo "ディレクトリ: $WORKTREE_ABSPATH"
+
+# worktree を強制的にクリーンな状態にする（削除済み追跡ファイルの復元・未追跡ファイルの削除）
+git -C "$WORKTREE_ABSPATH" restore . 2>/dev/null || true
+git -C "$WORKTREE_ABSPATH" clean -fd 2>/dev/null || true
 
 # WezTerm で新しいペインを開いて Claude を起動
 # ネイティブ: wezterm + WEZTERM_PANE が必要


### PR DESCRIPTION
Closes #145


## 変更内容

`create-worktree.sh` に worktree 作成前後のクリーンアップ処理を追加。

- **既存 worktree のリストア**: `git worktree add` 前に、既存の全 worktree に対して `git restore .` を実行し、追跡ファイルの変更を元に戻す
- **新規 worktree のクリーン化**: 作成直後の worktree に対して `git restore .` と `git clean -fd` を実行し、削除済み追跡ファイルの復元と未追跡ファイルの削除を行う
- bare リポジトリモード（モード1）と `~/.git-worktrees` モード（モード2）の両方に対応

## テスト方法

1. worktree ベース構造のリポジトリで `/gh-worktree-branch` を実行
2. 新規ブランチの worktree が作成されること、かつ worktree 内に余分なファイルや変更が残っていないことを確認
3. `~/.git-worktrees` 配下の bare リポジトリ構造でも同様に確認