### PR TITLE
fix: worktree削除済みファイルの伝播を修正

### DIFF
--- a/claude/skills/gh-worktree-branch/create-worktree.sh
+++ b/claude/skills/gh-worktree-branch/create-worktree.sh
@@ -16,15 +16,15 @@ if [ "$(basename "$GIT_COMMON")" = ".bare" ]; then
   WORKTREE_DIR="${CONTAINER_DIR}/${BRANCH}"
   echo "origin から最新を取得中..."
   git fetch origin
-  git worktree list --porcelain \
-    | awk '/^worktree /{print $2}' | grep -v '\.bare$' \
-    | while IFS= read -r wt; do [ -d "$wt" ] && git -C "$wt" restore . 2>/dev/null || true; done
   git worktree add -b "$BRANCH" "$WORKTREE_DIR"
 else
   # モード2: remote URL から ~/.git-worktrees/... の .bare が存在するか確認
   # なければ init-worktree.sh で自動作成してから worktree を追加
   REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
   WORKTREE_DIR=""
+
+  # ソース（現在のgitリポジトリ）で削除済みの追跡ファイルを記録
+  DELETED_FILES=$(git status --porcelain 2>/dev/null | awk '/^[ D]D /{print $NF}' || true)
 
   if [ -n "$REMOTE_URL" ]; then
     REPO_PATH=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
@@ -36,9 +36,6 @@ else
     fi
     echo "origin から最新を取得中..."
     GIT_DIR="${CANDIDATE}/.bare" git fetch origin
-    GIT_DIR="${CANDIDATE}/.bare" git worktree list --porcelain \
-      | awk '/^worktree /{print $2}' | grep -v '\.bare$' \
-      | while IFS= read -r wt; do [ -d "$wt" ] && git -C "$wt" restore . 2>/dev/null || true; done
     WORKTREE_DIR="${CANDIDATE}/${BRANCH}"
     GIT_DIR="${CANDIDATE}/.bare" git worktree add -b "$BRANCH" "$WORKTREE_DIR"
   else
@@ -54,8 +51,13 @@ echo "=== Worktree 作成完了 ==="
 echo "ブランチ: $BRANCH"
 echo "ディレクトリ: $WORKTREE_ABSPATH"
 
-# worktree を強制的にクリーンな状態にする（削除済み追跡ファイルの復元・未追跡ファイルの削除）
-git -C "$WORKTREE_ABSPATH" restore . 2>/dev/null || true
+# ソースの削除済みファイルを新規 worktree にも伝播
+if [ -n "${DELETED_FILES:-}" ]; then
+  while IFS= read -r f; do
+    rm -f "${WORKTREE_ABSPATH}/${f}"
+  done <<< "$DELETED_FILES"
+fi
+# 未追跡ファイルを削除
 git -C "$WORKTREE_ABSPATH" clean -fd 2>/dev/null || true
 
 # WezTerm で新しいペインを開いて Claude を起動


### PR DESCRIPTION
Closes #147


## 変更内容

worktree 作成スクリプトの削除済みファイル処理を改善。

- **削除**: 既存 worktree 全体に対して `git restore .` を実行していた処理を除去（意図しないファイル復元の原因）
- **追加**: ソースリポジトリで削除済みの追跡ファイルを検出し、新規作成した worktree にのみ伝播する処理を追加
- **維持**: 未追跡ファイルの削除（`git clean -fd`）は引き続き実行

### 変更前の問題
既存のすべての worktree に対して `git restore .` を実行していたため、削除済みファイルが意図せず復元されていた。

### 変更後の動作
- ソースの `git status` から削除済みファイルを検出
- 新規 worktree のみに対象ファイルの削除を伝播

## テスト方法

1. ソースリポジトリでファイルを削除した状態（`git rm` またはファイル削除後 `git add`）で worktree を作成
2. 新規 worktree に削除済みファイルが存在しないことを確認
3. 既存の worktree に影響がないことを確認