### PR TITLE
nvim設定: SSH対応とファイルフィルタ追加

### DIFF
--- a/wsl/.config/nvim/lua/plugins/markdown-preview.lua
+++ b/wsl/.config/nvim/lua/plugins/markdown-preview.lua
@@ -7,8 +7,17 @@ return {
     init = function()
       vim.g.mkdp_port = "8080"
       vim.g.mkdp_open_to_the_world = 1
-      vim.g.mkdp_open_ip = "100.120.150.49"  -- Tailscale IP
+      vim.g.mkdp_echo_preview_url = 1  -- URLをコマンドラインに表示
       vim.g.mkdp_open_browser_preview = 0  -- ブラウザ自動起動しない
+      -- SSH経由（Tailscale端末）はTailscale IP、ローカルはlocalhost
+      if os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY") then
+        local handle = io.popen("tailscale ip -4 2>/dev/null")
+        local ip = handle and handle:read("*l") or "100.120.150.49"
+        if handle then handle:close() end
+        vim.g.mkdp_open_ip = ip
+      else
+        vim.g.mkdp_open_ip = "127.0.0.1"
+      end
     end,
     keys = {
       { "<leader>mp", "<cmd>MarkdownPreviewToggle<cr>", ft = "markdown", desc = "Markdown Preview" },

--- a/wsl/.config/nvim/lua/plugins/nvim-tree.lua
+++ b/wsl/.config/nvim/lua/plugins/nvim-tree.lua
@@ -17,6 +17,13 @@ return {
         respect_buf_cwd = true,
         filters = {
           git_ignored = false,
+          custom = {
+            "\\.mp4$", "\\.mov$", "\\.avi$", "\\.mkv$", "\\.webm$",
+            "\\.mp3$", "\\.wav$", "\\.flac$", "\\.aac$",
+            "\\.png$", "\\.jpg$", "\\.jpeg$", "\\.gif$", "\\.webp$", "\\.svg$",
+            "\\.pdf$",
+            "\\.zip$", "\\.tar$", "\\.gz$", "\\.7z$",
+          },
         },
         on_attach = function(bufnr)
           local api = require("nvim-tree.api")


### PR DESCRIPTION
Closes #155


## 変更内容

- **markdown-preview**: `mkdp_open_ip` をハードコードから動的取得に変更。SSH接続時（`SSH_CLIENT`/`SSH_TTY`環境変数を検出）は `tailscale ip -4` コマンドで現在のTailscale IPを自動取得し、ローカル接続時は `127.0.0.1` を使用。またプレビューURLをコマンドラインに表示する `mkdp_echo_preview_url` を有効化。
- **nvim-tree**: 動画・音声・画像・PDF・アーカイブファイルをツリーから非表示にするカスタムフィルタを追加。

## テスト方法

- [ ] SSH経由でWSLに接続し、Markdownファイルを開いて `<leader>mp` を実行 → TailscaleのIPでプレビューURLが表示されること
- [ ] ローカルWSLで同操作 → `127.0.0.1:8080` のURLが表示されること
- [ ] nvim-treeを開き、`.mp4`・`.png`・`.pdf`・`.zip` などのファイルが非表示になっていること