### PR TITLE
nvim: csvviewにborder表示とタブナビ追加

### DIFF
--- a/wsl/.config/nvim/lua/plugins/csvview.lua
+++ b/wsl/.config/nvim/lua/plugins/csvview.lua
@@ -1,14 +1,25 @@
 return {
   "hat0uma/csvview.nvim",
-  opts = {},
+  opts = {
+    view = {
+      display_mode = "border",
+      header_lnum = true,
+      sticky_header = { enabled = true },
+    },
+  },
   cmd = { "CsvViewEnable", "CsvViewDisable", "CsvViewToggle" },
   ft = { "csv", "tsv" },
-  config = function()
-    require("csvview").setup()
+  config = function(_, opts)
+    require("csvview").setup(opts)
     vim.api.nvim_create_autocmd("FileType", {
       pattern = { "csv", "tsv" },
       callback = function()
         require("csvview").enable()
+        -- Tab/S-Tab でファイル全体のコンマを前後に移動（検索レジスタを汚さない）
+        vim.keymap.set("n", "<Tab>", function() vim.fn.search(",") end,
+          { buffer = true, silent = true, desc = "Next comma" })
+        vim.keymap.set("n", "<S-Tab>", function() vim.fn.search(",", "b") end,
+          { buffer = true, silent = true, desc = "Previous comma" })
       end,
     })
   end,


### PR DESCRIPTION
Closes #159


## 変更内容

`csvview.nvim` の設定を拡張し、以下を追加：

- **border表示モード**: `display_mode = "border"` でセル境界を罫線表示
- **スティッキーヘッダー**: `header_lnum` と `sticky_header` を有効化し、スクロール時もヘッダー行を固定表示
- **タブナビゲーション**: CSV/TSVファイルで `<Tab>` / `<S-Tab>` により次/前のカンマへジャンプ（検索レジスタを汚染しない）
- `config` 関数を `opts` を受け取る形式に修正し、`opts` を `setup()` に渡すよう改善

## テスト方法

1. CSV/TSVファイルを開く
2. `:CsvViewEnable` または自動有効化でビューを確認
3. border表示とスティッキーヘッダーが機能することを確認
4. `<Tab>` で次のカンマ、`<S-Tab>` で前のカンマにカーソルが移動することを確認