### PR TITLE
[codex] Fix YAML language server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ source ~/.bashrc
 nvm install --lts
 nvm use --lts
 npm install -g @anthropic-ai/claude-code
+npm install -g yaml-language-server
 ```
 
 既に Codex CLI を Windows 側だけに入れている場合でも、WSL のシェルから使うなら WSL 側にも入れる。

--- a/wsl/.config/nvim/lua/plugins/lsp.lua
+++ b/wsl/.config/nvim/lua/plugins/lsp.lua
@@ -9,19 +9,21 @@ return {
         lineFoldingOnly = true,
       }
 
-      vim.lsp.config("yamlls", {
-        capabilities = capabilities,
-        settings = {
-          yaml = {
-            validate = true,
-            completion = true,
-            hover = true,
-            keyOrdering = false,
+      if vim.fn.executable("yaml-language-server") == 1 then
+        vim.lsp.config("yamlls", {
+          capabilities = capabilities,
+          settings = {
+            yaml = {
+              validate = true,
+              completion = true,
+              hover = true,
+              keyOrdering = false,
+            },
           },
-        },
-      })
+        })
 
-      vim.lsp.enable("yamlls")
+        vim.lsp.enable("yamlls")
+      end
     end,
   },
 }


### PR DESCRIPTION
## Summary

- Guard Neovim `yamlls` setup so it only starts when `yaml-language-server` exists on PATH.
- Document `npm install -g yaml-language-server` in the WSL setup flow.

## Why

Fresh environments can open YAML files before the YAML language server has been installed. The previous config enabled `yamlls` unconditionally, which produced a blocking Neovim LSP startup error.

## Validation

- Confirmed `yaml-language-server --version` resolves locally after installation.
- Loaded the Neovim LSP plugin spec with `nvim --headless -u NONE -i NONE`.
- Compared `main...codex/fix-yaml-language-server-startup`; only `README.md` and `wsl/.config/nvim/lua/plugins/lsp.lua` changed.

Closes #185