### PR TITLE
[codex] Add codex -y shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,17 @@ Linux / WSL Ubuntu + Windows の設定ファイルを一元管理するリポジ
 │   ├── .gitconfig
 │   └── .bashrc
 │
-└── claude/                       # Claude Code 設定
-    ├── CLAUDE.md
-    ├── settings.json
-    ├── windows-notify.ps1
-    ├── github-app-config.env.example
-    ├── mcp/mcp-config.json.example
-    └── skills/（9ディレクトリ）
+├── claude/                       # Claude Code 設定
+│   ├── CLAUDE.md
+│   ├── settings.json
+│   ├── windows-notify.ps1
+│   ├── github-app-config.env.example
+│   ├── mcp/mcp-config.json.example
+│   └── skills/（9ディレクトリ）
+│
+└── codex/                        # Codex 設定
+    ├── config.toml
+    └── skills/
 ```
 
 ## 方針
@@ -260,6 +264,15 @@ vim ~/dotfiles/claude/CLAUDE.md
 | `~/dotfiles/windows/.gitconfig` | Windows の `~/.gitconfig` |
 | `~/dotfiles/claude/CLAUDE.md` | `~/.claude/CLAUDE.md` |
 | `~/dotfiles/claude/settings.json` | `~/.claude/settings.json` |
+| `~/dotfiles/codex/config.toml` | `~/.codex/config.toml` |
+
+### コマンド短縮
+
+WSL の zsh / bash では、`codex -y` を以下の短縮として使える。
+
+```bash
+codex --dangerously-bypass-approvals-and-sandbox
+```
 
 ### 変更を GitHub に保存する
 

--- a/wsl/.bashrc
+++ b/wsl/.bashrc
@@ -120,3 +120,14 @@ export PATH="$HOME/.local/bin:$PATH"
 if [ -f "$HOME/.cargo/env" ]; then
     . "$HOME/.cargo/env"
 fi
+
+# codex -y: --dangerously-bypass-approvals-and-sandbox の短縮
+unalias codex 2>/dev/null || true
+codex() {
+  if [ "${1:-}" = "-y" ]; then
+    shift
+    command codex --dangerously-bypass-approvals-and-sandbox "$@"
+  else
+    command codex "$@"
+  fi
+}

--- a/wsl/.local/bin/codex
+++ b/wsl/.local/bin/codex
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+self="$(realpath "$0")"
+real_codex=""
+
+IFS=':' read -r -a path_entries <<< "$PATH"
+for dir in "${path_entries[@]}"; do
+  candidate="${dir}/codex"
+  if [[ -x "$candidate" ]] && [[ "$(realpath "$candidate")" != "$self" ]]; then
+    real_codex="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$real_codex" ]]; then
+  echo "codex: real codex command not found in PATH" >&2
+  exit 127
+fi
+
+if [[ "${1:-}" == "-y" ]]; then
+  shift
+  exec "$real_codex" --dangerously-bypass-approvals-and-sandbox "$@"
+fi
+
+exec "$real_codex" "$@"

--- a/wsl/.zshrc
+++ b/wsl/.zshrc
@@ -221,6 +221,17 @@ claude() {
   fi
 }
 
+# codex -y: --dangerously-bypass-approvals-and-sandbox の短縮
+unalias codex 2>/dev/null || true
+codex() {
+  if [[ "$1" == "-y" ]]; then
+    shift
+    command codex --dangerously-bypass-approvals-and-sandbox "$@"
+  else
+    command codex "$@"
+  fi
+}
+
 # gh worktree branch: Issue作成 + worktree作成
 # gwb     → worktree作成してcd "path"をクリップボードにコピー
 # gwb r   → 右分割、gwb d → 下分割


### PR DESCRIPTION
## Summary

- Add a `codex -y` shortcut for `--dangerously-bypass-approvals-and-sandbox` in WSL shell startup files.
- Add a `~/.local/bin/codex` wrapper so the shortcut can work even when PATH resolution bypasses shell functions.
- Document the Codex config directory and shortcut usage in the README.

## Why

Fixes #187. Typing the full bypass flag is cumbersome, and the existing environment can resolve the nvm-installed Codex binary before shell functions depending on PATH initialization order.

## Validation

- `zsh -n wsl/.zshrc`
- `bash -n wsl/.bashrc`
- `bash -n wsl/.local/bin/codex`
- Verified a fresh zsh resolves `codex` as the wrapper/function and `codex -y --help` reaches Codex help without the unexpected `-y` error.