### PR TITLE
worktree-fzf: find コマンドの深さを修正し preview を追加

### DIFF
--- a/docs/qiita/terminal-shortcuts.md
+++ b/docs/qiita/terminal-shortcuts.md
@@ -248,7 +248,7 @@ Tailscale の IP（`100.x.x.x`）や MagicDNS 名がそのまま使える。
 
 | コマンド | 動作 | 由来 |
 |---------|------|------|
-| `Alt+W` | `~/.git-worktrees/` 以下の worktree を fzf で選択して `cd` | **W**orktree |
+| `Alt+W` | `~/.git-worktrees/` 以下のイシューベース worktree（`issue-*` パターン）を fzf で選択して `cd`（プレビュー表示付き） | **W**orktree |
 | `gwb` | GitHub Issue 作成 + worktree 作成 + WezTerm 下分割で Claude 起動 | **g**it **w**orktree **b**ranch |
 | `gwb r` | 同上・右分割 | **r**ight |
 | `gwb d` | 同上・下分割（`gwb` と同じ） | **d**own |

--- a/wsl/.zshrc
+++ b/wsl/.zshrc
@@ -205,16 +205,17 @@ function ghq-fzf() {
 zle -N ghq-fzf
 bindkey '^G' ghq-fzf
 
-# ~/.git-worktrees 以下の worktree ルートを fzf で選択して cd（.bare 除外）Alt+W
+# ~/.git-worktrees 以下のイシューベースの worktree を fzf で選択して cd（issue-XXX-* パターンのみ）Alt+W
 function worktree-fzf() {
   local base="$HOME/.git-worktrees"
 
   local target
   target=$(
-    find "$base" -mindepth 4 -maxdepth 4 -type d \
-    | rg -v '/\.bare$' \
+    find "$base" -mindepth 3 -maxdepth 3 -type d -name 'issue-*' \
     | sort \
-    | fzf --height=40% --reverse --prompt='worktree> '
+    | fzf --height=40% --reverse --prompt='worktree> ' \
+      --preview 'ls -la {} | head -20' \
+      --preview-window=right:30%
   ) || return
 
   cd "$target"


### PR DESCRIPTION
- worktree 構造が 3 段階に変更されたため、find コマンドの mindepth/maxdepth を 4→3 に修正
- issue-* パターンのみをフィルタリング（Issue ベースの worktree のみを表示）
- fzf に --preview を追加してパフォーマンス向上
- ドキュメント（terminal-shortcuts.md）を更新

これまで全画面待つまで候補が出てこない、またはサブフォルダも表示される問題を解決。

Fixes #193

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
