### PR TITLE
add: Azure devbox 起動/接続/停止コマンド

### DIFF
--- a/cloud/azure-devbox/README.md
+++ b/cloud/azure-devbox/README.md
@@ -1,0 +1,79 @@
+# Azure CLI 開発サーバー (devbox)
+
+Azure 上に CLI 専用の Linux 開発サーバー (Ubuntu 24.04) を立て、
+この dotfiles をベースに Claude Code / tmux / Neovim などをセットアップするための一式。
+
+## 構成
+
+| 項目 | 値 |
+|---|---|
+| VM サイズ | `Standard_B2s` (2 vCPU / 4 GiB, バースト型) |
+| リージョン | Japan East |
+| OS | Ubuntu 24.04 LTS |
+| ディスク | Standard SSD 30GB |
+| 認証 | SSH 鍵 |
+| ネットワーク | SSH(22) を作成元のグローバル IP からのみ許可 |
+| コスト対策 | 毎日 22:00 自動シャットダウン |
+
+## 使い方
+
+### 0. 事前準備
+```bash
+# Azure CLI 未導入なら
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+az login --use-device-code
+```
+
+### 1. VM を作成
+```bash
+bash create-vm.sh
+# サイズ等を変えたい場合は環境変数で上書き
+#   SIZE=Standard_B2ms LOCATION=japanwest bash create-vm.sh
+```
+
+### 2. 開発環境を流し込む
+```bash
+IP=$(az vm show -d -g rg-devbox -n devbox --query publicIps -o tsv)
+ssh azureuser@"$IP" 'bash -s' < bootstrap.sh
+```
+
+### 3. 各サービスにログイン (VM 内で)
+```bash
+ssh azureuser@"$IP"
+gh auth login
+claude            # 初回起動で認証
+```
+
+## 運用コマンド
+
+```bash
+# 使わない時は停止 → 課金はディスク代だけ (最大の節約)
+az vm deallocate -g rg-devbox -n devbox
+az vm start      -g rg-devbox -n devbox
+
+# CPU/メモリ増強 (要停止): 8GB=B2ms, 16GB=Standard_D4s_v5 など
+az vm deallocate -g rg-devbox -n devbox
+az vm resize     -g rg-devbox -n devbox --size Standard_B2ms
+az vm start      -g rg-devbox -n devbox
+
+# ディスク拡張 (要停止): 例 30→64GB
+az vm deallocate -g rg-devbox -n devbox
+DISK=$(az vm show -g rg-devbox -n devbox --query "storageProfile.osDisk.name" -o tsv)
+az disk update -g rg-devbox -n "$DISK" --size-gb 64
+az vm start -g rg-devbox -n devbox
+# VM 内で反映: sudo growpart /dev/sda 1 && sudo resize2fs /dev/sda1
+
+# 自宅 IP が変わって SSH できなくなったら許可元を更新
+MY_IP=$(curl -s https://ifconfig.me)
+az network nsg rule update -g rg-devbox --nsg-name devboxNSG \
+  -n allow-ssh-home --source-address-prefixes "${MY_IP}/32"
+
+# まるごと削除 (後片付け)
+az group delete -n rg-devbox --yes
+```
+
+## メモ
+
+- 公開 IP は Standard SKU のため **静的**。停止→再開しても変わらない。
+- `.zshrc` 内の WSL 専用関数 (`wpath` / `wcd` / clip.exe 連携等) は存在チェックで
+  ガードされており、純 Linux VM では no-op になる。

--- a/cloud/azure-devbox/bootstrap.sh
+++ b/cloud/azure-devbox/bootstrap.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# =============================================================
+# Azure 開発サーバー (Ubuntu 24.04) に開発環境を流し込む。
+#   必要パッケージ → ghq / Node(nvm) / Claude Code → dotfiles 適用 → zsh
+# 冪等: 何度実行しても安全。
+#
+# 使い方 (ローカルから VM へ):
+#   ssh azureuser@<IP> 'bash -s' < bootstrap.sh
+# =============================================================
+
+echo "########## 1) apt パッケージ ##########"
+sudo apt-get update -qq
+sudo apt-get install -y -qq \
+  zsh neovim git curl wget build-essential tmux \
+  fzf zoxide golang-go unzip ca-certificates jq
+
+echo "########## 2) GitHub CLI (gh) ##########"
+if ! command -v gh >/dev/null 2>&1; then
+  sudo mkdir -p -m 755 /etc/apt/keyrings
+  wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq gh
+fi
+echo "gh: $(gh --version | head -1)"
+
+echo "########## 3) ghq (go install) ##########"
+export PATH="$HOME/go/bin:$PATH"
+if ! command -v ghq >/dev/null 2>&1; then
+  go install github.com/x-motemen/ghq@latest
+fi
+echo "ghq: $("$HOME/go/bin/ghq" --version 2>/dev/null || echo installed)"
+
+echo "########## 4) nvm + Node LTS + Claude Code ##########"
+export NVM_DIR="$HOME/.nvm"
+if [ ! -d "$NVM_DIR" ]; then
+  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+fi
+# shellcheck disable=SC1091
+. "$NVM_DIR/nvm.sh"
+nvm install --lts >/dev/null
+nvm use --lts >/dev/null
+echo "node: $(node -v) / npm: $(npm -v)"
+npm install -g @anthropic-ai/claude-code
+echo "claude: $(claude --version 2>/dev/null || echo 'installed (要ログイン)')"
+
+echo "########## 5) dotfiles clone & install ##########"
+if [ ! -d "$HOME/dotfiles" ]; then
+  git clone https://github.com/AutoFor/dotfiles.git "$HOME/dotfiles"
+else
+  git -C "$HOME/dotfiles" pull --ff-only || true
+fi
+# 非 WSL なので wsl.conf 等のシステム設定はスキップ
+INSTALL_SYSTEM_CONFIG=0 bash "$HOME/dotfiles/install.sh"
+
+echo "########## 6) デフォルトシェルを zsh に ##########"
+ZSH_PATH="$(command -v zsh)"
+if [ "$(getent passwd "$USER" | cut -d: -f7)" != "$ZSH_PATH" ]; then
+  sudo chsh -s "$ZSH_PATH" "$USER"
+  echo "default shell -> $ZSH_PATH"
+else
+  echo "default shell は既に zsh"
+fi
+
+echo "########## 完了 ##########"
+echo "次にやること:  gh auth login   /   claude  (初回ログイン)"

--- a/cloud/azure-devbox/create-vm.sh
+++ b/cloud/azure-devbox/create-vm.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================
+# Azure に CLI 専用 Linux 開発サーバー (Ubuntu 24.04) を作成する
+#   - Standard_B2s (2 vCPU / 4 GiB, バースト型・低コスト)
+#   - Standard SSD 30GB / SSH 鍵認証
+#   - SSH(22) は実行元のグローバル IP からのみ許可
+#   - 毎日 22:00 に自動シャットダウン
+#
+# 前提: `az login` 済み。
+# 使い方: bash create-vm.sh   (変数は環境変数で上書き可)
+#   例) SIZE=Standard_B2ms LOCATION=japanwest bash create-vm.sh
+#
+# 作成後に開発環境を流し込む場合:
+#   IP=$(az vm show -d -g "$RG" -n "$VM" --query publicIps -o tsv)
+#   ssh azureuser@"$IP" 'bash -s' < bootstrap.sh
+# =============================================================
+
+# ---- 調整可能な変数 --------------------------------------------
+RG="${RG:-rg-devbox}"
+LOCATION="${LOCATION:-japaneast}"
+VM="${VM:-devbox}"
+SIZE="${SIZE:-Standard_B2s}"
+ADMIN="${ADMIN:-azureuser}"
+OS_DISK_GB="${OS_DISK_GB:-30}"
+IMAGE="${IMAGE:-Ubuntu2404}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519.pub}"
+# ----------------------------------------------------------------
+
+# SSH 鍵が無ければ生成
+if [ ! -f "$SSH_KEY" ]; then
+  echo ">> SSH 鍵が無いので生成: ${SSH_KEY%.pub}"
+  ssh-keygen -t ed25519 -f "${SSH_KEY%.pub}" -N ""
+fi
+
+# 実行元のグローバル IP を取得 (SSH をこの IP からだけ許可)
+MY_IP="$(curl -s https://ifconfig.me)"
+echo ">> SSH 許可元 IP: ${MY_IP}"
+
+# 1) リソースグループ
+az group create -n "$RG" -l "$LOCATION" -o none
+
+# 2) VM 作成 (Standard SSD / SSH 鍵認証 / 受信ルールは後で手動)
+az vm create \
+  -g "$RG" -n "$VM" \
+  --image "$IMAGE" \
+  --size "$SIZE" \
+  --admin-username "$ADMIN" \
+  --ssh-key-values "$SSH_KEY" \
+  --os-disk-size-gb "$OS_DISK_GB" \
+  --storage-sku StandardSSD_LRS \
+  --public-ip-sku Standard \
+  --nsg-rule NONE \
+  -o table
+
+# 3) SSH(22) を実行元 IP からのみ許可
+az network nsg rule create \
+  -g "$RG" --nsg-name "${VM}NSG" \
+  -n allow-ssh-home --priority 1000 \
+  --access Allow --protocol Tcp --direction Inbound \
+  --source-address-prefixes "${MY_IP}/32" \
+  --destination-port-ranges 22 -o none
+
+# 4) コスト対策: 毎日 22:00 (テナント既定 TZ) に自動シャットダウン
+az vm auto-shutdown -g "$RG" -n "$VM" --time 2200 -o none
+
+# 5) 接続情報
+IP="$(az vm show -d -g "$RG" -n "$VM" --query publicIps -o tsv)"
+echo "=============================================="
+echo " 接続:  ssh ${ADMIN}@${IP}"
+echo " 開発環境の流し込み:"
+echo "   ssh ${ADMIN}@${IP} 'bash -s' < $(dirname "$0")/bootstrap.sh"
+echo "=============================================="

--- a/wsl/.local/bin/devbox
+++ b/wsl/.local/bin/devbox
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Azure 開発サーバー (devbox) に接続する。
+#   - 停止中(deallocated)なら自動で起動してから SSH する
+#   - az 未導入 / 未ログイン / 接続失敗時はローカルのログインシェルにフォールバック
+#   - SSH を抜けた後もローカルシェルに戻る
+#
+# 環境変数で上書き可: DEVBOX_RG / DEVBOX_VM / DEVBOX_USER / DEVBOX_IP
+set -uo pipefail
+
+RG="${DEVBOX_RG:-rg-devbox}"
+VM="${DEVBOX_VM:-devbox}"
+USER_NAME="${DEVBOX_USER:-azureuser}"
+IP="${DEVBOX_IP:-20.46.165.130}"   # Standard SKU の静的 IP（停止/再開で不変）
+
+connect() {
+  if ! command -v az >/dev/null 2>&1; then
+    echo "⚠ az CLI が無いため Azure に接続できません。" >&2
+    return 1
+  fi
+  if ! az account show >/dev/null 2>&1; then
+    echo "⚠ az 未ログインです。'az login --use-device-code' を実行してください。" >&2
+    return 1
+  fi
+
+  local state
+  state=$(az vm get-instance-view -g "$RG" -n "$VM" \
+    --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" \
+    -o tsv 2>/dev/null || true)
+
+  if [ "$state" != "PowerState/running" ]; then
+    echo "▶ devbox を起動中... (現在: ${state:-unknown})"
+    if ! az vm start -g "$RG" -n "$VM" -o none; then
+      echo "⚠ devbox の起動に失敗しました。" >&2
+      return 1
+    fi
+  fi
+
+  echo "🔗 ssh ${USER_NAME}@${IP}"
+  ssh -o StrictHostKeyChecking=accept-new "${USER_NAME}@${IP}"
+}
+
+connect || echo "（ローカルシェルに切り替えました）" >&2
+exec "${SHELL:-/usr/bin/zsh}" -l

--- a/wsl/.local/bin/devbox-down
+++ b/wsl/.local/bin/devbox-down
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Azure 開発サーバー (devbox) を停止(deallocate)するコマンド。
+# 停止すると課金はディスク代だけになる（節約）。再開は `devbox-up` か `devbox`。
+# 環境変数で上書き可: DEVBOX_RG / DEVBOX_VM
+set -uo pipefail
+
+RG="${DEVBOX_RG:-rg-devbox}"
+VM="${DEVBOX_VM:-devbox}"
+
+if ! az account show >/dev/null 2>&1; then
+  echo "⚠ az 未ログインです。'az login --use-device-code' を実行してください。" >&2
+  exit 1
+fi
+
+state=$(az vm get-instance-view -g "$RG" -n "$VM" \
+  --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv 2>/dev/null || true)
+
+if [ "$state" = "PowerState/deallocated" ]; then
+  echo "✅ devbox は既に停止しています"
+else
+  echo "■ devbox を停止(deallocate)中... (現在: ${state:-unknown})"
+  az vm deallocate -g "$RG" -n "$VM" -o none && echo "✅ 停止完了（課金はディスク代のみ）"
+fi

--- a/wsl/.local/bin/devbox-up
+++ b/wsl/.local/bin/devbox-up
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Azure 開発サーバー (devbox) を起動するだけのコマンド（SSH はしない）。
+# 接続もしたいときは `devbox` を使う。
+# 環境変数で上書き可: DEVBOX_RG / DEVBOX_VM
+set -uo pipefail
+
+RG="${DEVBOX_RG:-rg-devbox}"
+VM="${DEVBOX_VM:-devbox}"
+
+if ! az account show >/dev/null 2>&1; then
+  echo "⚠ az 未ログインです。'az login --use-device-code' を実行してください。" >&2
+  exit 1
+fi
+
+state=$(az vm get-instance-view -g "$RG" -n "$VM" \
+  --query "instanceView.statuses[?starts_with(code,'PowerState/')].code | [0]" -o tsv 2>/dev/null || true)
+
+if [ "$state" = "PowerState/running" ]; then
+  echo "✅ devbox は既に起動中です"
+else
+  echo "▶ devbox を起動中... (現在: ${state:-unknown})"
+  az vm start -g "$RG" -n "$VM" -o none && echo "✅ 起動完了"
+fi
+
+ip=$(az vm show -d -g "$RG" -n "$VM" --query publicIps -o tsv 2>/dev/null || true)
+[ -n "$ip" ] && echo "🔗 ssh azureuser@${ip}   (または devbox で接続)"


### PR DESCRIPTION
## 概要
WSL から Azure 開発サーバー (devbox) を簡単に操作するスクリプト3本を追加。

| コマンド | 動作 |
|---|---|
| `devbox` | 停止中なら自動起動して SSH 接続（az未ログイン/失敗時はローカルにフォールバック） |
| `devbox-up` | 起動だけ（接続しない・IP 表示） |
| `devbox-down` | 停止(deallocate)して課金をディスク代のみに節約 |

いずれも `install.sh` で `~/.local/bin` にリンクされる。RG/VM 名等は環境変数で上書き可。

実機で起動・状態判定・SSH 到達を確認済み。

## 補足
- WezTerm 既定を Azure に置き換える `windows/.wezterm.lua` の変更は、別件の未コミット作業と同ファイルに混在しているため本PRには含めていない（別途対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)